### PR TITLE
Add a new metric which indicate the punctuality of the block head

### DIFF
--- a/pkg/exporter/execution/jobs/block.go
+++ b/pkg/exporter/execution/jobs/block.go
@@ -28,6 +28,7 @@ type BlockMetrics struct {
 	HeadBaseFeePerGas    prometheus.Gauge
 	HeadBlockSize        prometheus.Gauge
 	HeadTransactionCount prometheus.Gauge
+	HeadPunctuality      prometheus.Gauge
 
 	SafeGasUsed          prometheus.Counter
 	SafeGasLimit         prometheus.Counter
@@ -115,6 +116,14 @@ func NewBlockMetrics(client *ethclient.Client, internalAPI api.ExecutionClient, 
 				Namespace:   namespace,
 				Name:        "head_transactions_in_block",
 				Help:        "The number of transactions in the most recent block.",
+				ConstLabels: constLabels,
+			},
+		),
+		HeadPunctuality: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace:   namespace,
+				Name:        "head_punctuality",
+				Help:        "The punctuality of the most recent block.",
 				ConstLabels: constLabels,
 			},
 		),
@@ -214,6 +223,7 @@ func (b *BlockMetrics) getHeadBlockStats(ctx context.Context) error {
 	b.HeadBlockSize.Set(float64(block.Size))
 	b.HeadTransactionCount.Set(float64(len(block.Transactions)))
 	// b.HeadBaseFeePerGas.Set(float64(block.BaseFee().Int64())) TODO(sam.calder-mason): Fix me
+	b.HeadPunctuality.Set(float64((int64(block.Timestamp) * 1000) - time.Now().UnixMilli()))
 
 	return nil
 }

--- a/pkg/exporter/execution/metrics.go
+++ b/pkg/exporter/execution/metrics.go
@@ -80,6 +80,7 @@ func NewMetrics(client *ethclient.Client, internalAPI api.ExecutionClient, ethRP
 		prometheus.MustRegister(m.blockMetrics.HeadGasUsed)
 		prometheus.MustRegister(m.blockMetrics.HeadTransactionCount)
 		prometheus.MustRegister(m.blockMetrics.HeadBaseFeePerGas)
+		prometheus.MustRegister(m.blockMetrics.HeadPunctuality)
 
 		prometheus.MustRegister(m.blockMetrics.SafeBaseFeePerGas)
 		prometheus.MustRegister(m.blockMetrics.SafeBlockSize)


### PR DESCRIPTION
Measure the difference of the head block timestamp compared to current timestamp. This will help to identify if the node is behind and how far behind.

Unit: time in milliseconds