### PR TITLE
feat: add disk usage as a metric

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,6 +35,8 @@ var (
 	consensusURL         string
 	monitoredDirectories []string
 	executionModules     []string
+	executionDBPath      string
+	consensusDBPath      string
 )
 
 const (
@@ -57,6 +59,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&consensusURL, "consensus-url", "", "", "(optional) URL to the consensus node")
 	rootCmd.PersistentFlags().StringSliceVarP(&monitoredDirectories, "monitored-directories", "", []string{}, "(optional) directories to monitor for disk usage")
 	rootCmd.PersistentFlags().StringSliceVarP(&executionModules, "execution-modules", "", []string{}, "(optional) execution modules that are enabled on the node")
+	rootCmd.PersistentFlags().StringVar(&executionDBPath, "execution-db-path", "", "(optional) path to the execution layer database")
+	rootCmd.PersistentFlags().StringVar(&consensusDBPath, "consensus-db-path", "", "(optional) path to the consensus layer database")
 
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
@@ -110,6 +114,16 @@ func initCommon() {
 
 	if len(executionModules) > 0 {
 		config.Execution.Modules = executionModules
+	}
+
+	if executionDBPath != "" {
+		config.Execution.DBPath = executionDBPath
+		config.DiskUsage.Enabled = true
+	}
+
+	if consensusDBPath != "" {
+		config.Consensus.DBPath = consensusDBPath
+		config.DiskUsage.Enabled = true
 	}
 
 	export = exporter.NewExporter(log, config)

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -2,10 +2,12 @@ consensus:
   enabled: true
   url: "http://localhost:5053"
   name: "consensus-client"
+  dbPath: "/data/consensus-db"
 execution:
   enabled: true
   url: "http://localhost:8545"
   name: "execution-client"
+  dbPath: "/data/execution-db"
   modules:
     - "eth"
     - "net"

--- a/pkg/exporter/config.go
+++ b/pkg/exporter/config.go
@@ -24,6 +24,7 @@ type ConsensusNode struct {
 	Name        string      `yaml:"name"`
 	URL         string      `yaml:"url"`
 	EventStream EventStream `yaml:"eventStream"`
+	DBPath      string      `yaml:"dbPath"` // Path to the consensus layer database
 }
 
 type EventStream struct {
@@ -37,6 +38,7 @@ type ExecutionNode struct {
 	Name    string   `yaml:"name"`
 	URL     string   `yaml:"url"`
 	Modules []string `yaml:"modules"`
+	DBPath  string   `yaml:"dbPath"` // Path to the execution layer database
 }
 
 // DiskUsage configures the exporter to expose disk usage stats for these directories.

--- a/pkg/exporter/disk/metrics.go
+++ b/pkg/exporter/disk/metrics.go
@@ -31,6 +31,7 @@ func NewMetrics(log logrus.FieldLogger, namespace string) Metrics {
 			},
 			[]string{
 				"directory",
+				"type",
 			},
 		),
 	}
@@ -41,5 +42,5 @@ func NewMetrics(log logrus.FieldLogger, namespace string) Metrics {
 }
 
 func (m *metrics) ObserveDiskUsage(usage Usage) {
-	m.diskUsage.WithLabelValues(usage.Directory).Set(float64(usage.UsageBytes))
+	m.diskUsage.WithLabelValues(usage.Directory, usage.Type).Set(float64(usage.UsageBytes))
 }

--- a/pkg/exporter/disk/usage.go
+++ b/pkg/exporter/disk/usage.go
@@ -4,4 +4,5 @@ package disk
 type Usage struct {
 	Directory  string
 	UsageBytes int64
+	Type       string // Type of directory: "el_db", "cl_db", or "general"
 }


### PR DESCRIPTION
Tested with kt:
```
# TYPE eth_disk_usage_bytes gauge
eth_disk_usage_bytes{directory="/data/consensus-db",type="cl_db"} 1.01263824e+08
eth_disk_usage_bytes{directory="/data/execution-db",type="el_db"} 3.86592107e+09
```