### PR TITLE
fix: handle both hex and uint formats for TxPoolStatus

### DIFF
--- a/pkg/exporter/execution/api/types/txpool.go
+++ b/pkg/exporter/execution/api/types/txpool.go
@@ -1,9 +1,74 @@
 package types
 
-import "github.com/ethereum/go-ethereum/common/hexutil"
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
 
 // TXPoolStatus is the information about the transaction pool.
 type TXPoolStatus struct {
 	Pending hexutil.Uint64 `json:"pending"`
 	Queued  hexutil.Uint64 `json:"queued"`
+}
+
+// UnmarshalJSON implements custom unmarshaling to handle both hex (Geth) and uint (Nethermind) formats
+func (t *TXPoolStatus) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal into a map first to handle both formats
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Helper function to parse either hex string or number
+	parseValue := func(key string) (hexutil.Uint64, error) {
+		val, ok := raw[key]
+		if !ok {
+			return 0, nil // Field not present, use zero value
+		}
+
+		switch v := val.(type) {
+		case string:
+			// Handle hex string (Geth format)
+			if strings.HasPrefix(v, "0x") || strings.HasPrefix(v, "0X") {
+				decoded, err := hexutil.DecodeUint64(v)
+				if err != nil {
+					return 0, fmt.Errorf("failed to decode hex value for %s: %w", key, err)
+				}
+				return hexutil.Uint64(decoded), nil
+			}
+			// Try parsing as decimal string
+			n, err := strconv.ParseUint(v, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse string value for %s: %w", key, err)
+			}
+			return hexutil.Uint64(n), nil
+		case float64:
+			// Handle numeric value (Nethermind format)
+			if v < 0 || v > float64(^uint64(0)) {
+				return 0, fmt.Errorf("value for %s out of uint64 range: %v", key, v)
+			}
+			return hexutil.Uint64(uint64(v)), nil
+		default:
+			return 0, fmt.Errorf("unexpected type for %s: %T", key, v)
+		}
+	}
+
+	// Parse pending and queued values
+	pending, err := parseValue("pending")
+	if err != nil {
+		return err
+	}
+	t.Pending = pending
+
+	queued, err := parseValue("queued")
+	if err != nil {
+		return err
+	}
+	t.Queued = queued
+
+	return nil
 }

--- a/pkg/exporter/execution/api/types/txpool_test.go
+++ b/pkg/exporter/execution/api/types/txpool_test.go
@@ -1,0 +1,188 @@
+package types
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+func TestTXPoolStatus_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    TXPoolStatus
+		wantErr bool
+	}{
+		{
+			name: "Geth format with hex strings",
+			input: `{
+				"pending": "0x128",
+				"queued": "0x0"
+			}`,
+			want: TXPoolStatus{
+				Pending: hexutil.Uint64(0x128), // 296 in decimal
+				Queued:  hexutil.Uint64(0x0),   // 0 in decimal
+			},
+			wantErr: false,
+		},
+		{
+			name: "Nethermind format with numbers",
+			input: `{
+				"pending": 16,
+				"queued": 0
+			}`,
+			want: TXPoolStatus{
+				Pending: hexutil.Uint64(16),
+				Queued:  hexutil.Uint64(0),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Mixed format",
+			input: `{
+				"pending": "0x10",
+				"queued": 5
+			}`,
+			want: TXPoolStatus{
+				Pending: hexutil.Uint64(0x10), // 16 in decimal
+				Queued:  hexutil.Uint64(5),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Large hex values",
+			input: `{
+				"pending": "0xffffffff",
+				"queued": "0x1234abcd"
+			}`,
+			want: TXPoolStatus{
+				Pending: hexutil.Uint64(0xffffffff),
+				Queued:  hexutil.Uint64(0x1234abcd),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing fields defaults to zero",
+			input: `{
+				"pending": "0x10"
+			}`,
+			want: TXPoolStatus{
+				Pending: hexutil.Uint64(0x10),
+				Queued:  hexutil.Uint64(0),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "Empty object",
+			input:   `{}`,
+			want:    TXPoolStatus{},
+			wantErr: false,
+		},
+		{
+			name: "Invalid hex string",
+			input: `{
+				"pending": "0xg123",
+				"queued": "0x0"
+			}`,
+			wantErr: true,
+		},
+		{
+			name: "Negative number",
+			input: `{
+				"pending": -1,
+				"queued": 0
+			}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got TXPoolStatus
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TXPoolStatus.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Pending != tt.want.Pending {
+					t.Errorf("TXPoolStatus.UnmarshalJSON() Pending = %v, want %v", got.Pending, tt.want.Pending)
+				}
+				if got.Queued != tt.want.Queued {
+					t.Errorf("TXPoolStatus.UnmarshalJSON() Queued = %v, want %v", got.Queued, tt.want.Queued)
+				}
+			}
+		})
+	}
+}
+
+func TestTXPoolStatus_UnmarshalJSON_FullResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    TXPoolStatus
+		wantErr bool
+	}{
+		{
+			name: "Geth full RPC response",
+			input: `{
+				"jsonrpc": "2.0",
+				"id": 1,
+				"result": {
+					"pending": "0x128",
+					"queued": "0x0"
+				}
+			}`,
+			want: TXPoolStatus{
+				Pending: hexutil.Uint64(0x128), // 296 in decimal
+				Queued:  hexutil.Uint64(0x0),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Nethermind full RPC response",
+			input: `{
+				"jsonrpc": "2.0",
+				"result": {
+					"pending": 16,
+					"queued": 0
+				},
+				"id": 1
+			}`,
+			want: TXPoolStatus{
+				Pending: hexutil.Uint64(16),
+				Queued:  hexutil.Uint64(0),
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// First unmarshal to get the result field
+			var rpcResponse struct {
+				Result json.RawMessage `json:"result"`
+			}
+			if err := json.Unmarshal([]byte(tt.input), &rpcResponse); err != nil {
+				t.Fatalf("Failed to unmarshal RPC response: %v", err)
+			}
+
+			// Then unmarshal the result into TXPoolStatus
+			var got TXPoolStatus
+			err := json.Unmarshal(rpcResponse.Result, &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TXPoolStatus.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Pending != tt.want.Pending {
+					t.Errorf("TXPoolStatus.UnmarshalJSON() Pending = %v, want %v", got.Pending, tt.want.Pending)
+				}
+				if got.Queued != tt.want.Queued {
+					t.Errorf("TXPoolStatus.UnmarshalJSON() Queued = %v, want %v", got.Queued, tt.want.Queued)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add custom UnmarshalJSON to handle both Geth (hex) and Nethermind (uint) formats
- Support both `"0x128"` hex strings and `16` numeric values
- Add comprehensive test coverage for both formats

## Test plan
- Run `go test -v ./pkg/exporter/execution/api/types/...`
- All tests pass including edge cases