### PR TITLE
fix: prevent nil pointer dereference when admin_nodeInfo omits difficulty

### DIFF
--- a/pkg/exporter/execution/api/types/admin.go
+++ b/pkg/exporter/execution/api/types/admin.go
@@ -65,7 +65,7 @@ func (e *EthProtocol) UnmarshalJSON(data []byte) error {
 		}
 	} else {
 		// difficulty key missing (e.g. post-merge clients), unmarshal rest of struct
-		if err = json.Unmarshal(data, &v); err != nil {
+		if err := json.Unmarshal(data, &v); err != nil {
 			return err
 		}
 	}

--- a/pkg/exporter/execution/api/types/admin.go
+++ b/pkg/exporter/execution/api/types/admin.go
@@ -50,15 +50,22 @@ func (e *EthProtocol) UnmarshalJSON(data []byte) error {
 	}
 
 	var difficultyString string
-	if err := json.Unmarshal(*objMap["difficulty"], &difficultyString); err != nil {
-		// Its probably just an int, return the entire thing like normal
-		err = json.Unmarshal(data, &v)
-		if err != nil {
-			return err
+	if difficultyRaw := objMap["difficulty"]; difficultyRaw != nil {
+		if err := json.Unmarshal(*difficultyRaw, &difficultyString); err != nil {
+			// Its probably just an int, return the entire thing like normal
+			err = json.Unmarshal(data, &v)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Try and parse the string back in to a big.Int
+			if v.Difficulty, err = hexutil.DecodeBig(difficultyString); err != nil {
+				return err
+			}
 		}
 	} else {
-		// Try and parse the string back in to a big.Int
-		if v.Difficulty, err = hexutil.DecodeBig(difficultyString); err != nil {
+		// difficulty key missing (e.g. post-merge clients), unmarshal rest of struct
+		if err = json.Unmarshal(data, &v); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Problem

The exporter panics with a nil pointer dereference when calling `admin_nodeInfo` against Geth (and potentially other clients) that omit the `difficulty` field from the response. This commonly occurs with post-merge clients where difficulty is no longer relevant.

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/ethpandaops/ethereum-metrics-exporter/pkg/exporter/execution/api/types.(*EthProtocol).UnmarshalJSON
    pkg/exporter/execution/api/types/admin.go:53
```

## Root Cause

In `EthProtocol.UnmarshalJSON`, the code dereferences `objMap["difficulty"]` without checking if the key exists. When `difficulty` is missing from the JSON, `objMap["difficulty"]` is nil and `*objMap["difficulty"]` causes the panic.

## Solution

- Add a nil check before accessing `objMap["difficulty"]`
- When the key is present: preserve existing behavior (parse as hex string or fall back to standard unmarshal)
- When the key is missing: unmarshal the rest of the struct and leave `Difficulty` as nil